### PR TITLE
Make a filename descriptive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2200,6 +2200,11 @@
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
       "dev": true
     },
+    "dayjs": {
+      "version": "1.8.31",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.31.tgz",
+      "integrity": "sha512-mPh1mslned+5PuIuiUfbw4CikHk6AEAf2Baxih+wP5fssv+wmlVhvgZ7mq+BhLt7Sr/Hc8leWDiwe6YnrpNt3g=="
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",

--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
     "webpack-dev-server": "^3.10.3",
     "webpack-merge": "^4.2.2",
     "write-file-webpack-plugin": "^4.5.1"
+  },
+  "dependencies": {
+    "dayjs": "^1.8.31"
   }
 }

--- a/src/scripts/main.ts
+++ b/src/scripts/main.ts
@@ -1,3 +1,5 @@
+import * as dayjs from 'dayjs';
+
 import { Utility } from './utility';
 import { VideoLayer } from './video-layer';
 import { Capturer } from './capturer';
@@ -37,7 +39,8 @@ shutterButton.addEventListener('click', () => {
     .then((image: HTMLImageElement) => {
       const anchor = document.createElement('a');
       anchor.href = image.src;
-      anchor.download = 'image.png';
+      const time = dayjs().format('YYYYMMDD-HHmmss');
+      anchor.download = `daipan-${time}.png`;
       anchor.target = '_blank';
       anchor.click();
     });

--- a/src/scripts/main.ts
+++ b/src/scripts/main.ts
@@ -40,7 +40,7 @@ shutterButton.addEventListener('click', () => {
       const anchor = document.createElement('a');
       anchor.href = image.src;
       const time = dayjs().format('YYYYMMDD-HHmmss');
-      anchor.download = `daipan-${time}.png`;
+      anchor.download = `diapan-${time}.png`;
       anchor.target = '_blank';
       anchor.click();
     });


### PR DESCRIPTION
Kiranichiwa! 🙂

**Problem**
Currently, when tapping a 💎 button, the downloaded filename becomes `image.png`. If we save multiple images, the filename will be `image (1).png`, `image (2).png`, and so on. These names are a little ugly.

**What this PR fixes**
This PR changes the saved filename from `image.png` to the following format: `diapan-YYYYMMDD-HHmmss.png` (for example, `diapan-20200801-235959.png`). This format can avoid the duplication among filenames and makes it more clear when the photo is saved and what the photo is about without opening it.

**Comments**
- I chose the format `diapan-YYYYMMDD-HHmmss.png` but this can be changed if you want.
- I added dayjs as a dependency. This library has only 2 KB and I assume it is acceptable.